### PR TITLE
Allow unauthenticated users to vote and see results of polls

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -666,7 +666,7 @@ class PollBlock(PollBase, CSVExportMixin):
         else:
         # Get tally from the db directly
             tally = self.get_tally()
-            if not self.runtime._services['user'].get_current_user().opt_attrs['edx-platform.is_authenticated'] and tally:
+            if self.is_anonymous_user() and tally:
                 # Check if user is unauthenticated and tally exists as well
                 self.tally = tally
                 self._clear_dirty_fields()
@@ -725,7 +725,7 @@ class PollBlock(PollBase, CSVExportMixin):
         
         # Get tally from the db directly
         tally = self.get_tally()
-        if not self.runtime._services['user'].get_current_user().opt_attrs['edx-platform.is_authenticated'] and tally:
+        if self.is_anonymous_user() and tally:
             # Check if user is unauthenticated and
             # Tally exists, meaning this is not the first vote on the poll
             return self.handle_anonymous_vote(choice, result, tally)
@@ -751,6 +751,12 @@ class PollBlock(PollBase, CSVExportMixin):
             return None
         # Tally is a dict stored as string, convert to json
         return json.loads(query_set.value)
+
+    def is_anonymous_user(self):
+        """
+        Return if the current user is authenticated or not
+        """
+        return not self.runtime._services['user'].get_current_user().opt_attrs['edx-platform.is_authenticated']
 
     def handle_anonymous_vote(self, choice, result, tally):
         """

--- a/poll/public/js/poll.js
+++ b/poll/public/js/poll.js
@@ -138,6 +138,7 @@ function PollUtil (runtime, element, pollType) {
         }
         var can_vote = data['can_vote'];
         $('.poll-current-count', element).text(data['submissions_count']);
+        $('.poll-max-submissions', element).text(data['max_submissions']);
         if (data['max_submissions'] > 1) {
             $('.poll-submissions-count', element).show();
         }


### PR DESCRIPTION
**Changes**

- Added a service to the edx-platform runtime through which we can get the tally of the poll and can update the tally as well
- Anonymous voter can see the results of the poll after voting as well now

**Service**
A service was necessary as the `FieldDataCache` object was being used by the xblocks to store and update data. `FieldDataCache` was not storing or fetching cache for anonymous users. As the cache was not present in the case of anonymous users, the ORM would try to add a new entry for the poll with the same primary key, thereby resulting in an integrity error.

To get around this and not having to change the `FieldDataCache` class, we decided to create a service and then update the tally in the database ourselves rather than let the LMS handle it in the case of an anonymous users vote.

**IP Hashing**

IP hashing was not done as xblocks in openedx have a `student_module` table where they store every interaction of the student with every single xblock. Each vote of the poll by an authenticated user is stored there. Xblocks manage this data themselves and they do not keep a similar record for unauthenticated users. 

Unauthenticated users have their state managed for the session by the LMS itself and then the data is deleted. To store IP hash, we will need to keep track of unauthenticated users ourselves. For that reason, we would have had to create a new model and store the IP hash there. To avoid the scenario of running migrations, we did not go through with this idea.

**Authenticated users flow**

Authenticated users have no difference in the experience from before.

**Fixes**

- Max_submissions was not rendering when max_submissions is set to more than 1. That is now fixed. The issue was that the max_submissions value was not being set on frontend after getting the response from the backend.

